### PR TITLE
Fix link text and other missing copy

### DIFF
--- a/app/assets/stylesheets/costs/main.scss
+++ b/app/assets/stylesheets/costs/main.scss
@@ -40,6 +40,6 @@
     border-left: none;
     border-top: var(--border-brand);
     padding-left: 0;
-    padding-top: 0.5rem;
+    padding-top: .5rem;
   }
 }

--- a/app/assets/stylesheets/costs/main.scss
+++ b/app/assets/stylesheets/costs/main.scss
@@ -1,7 +1,6 @@
 .cost {
   border-left: var(--border-brand);
   padding-left: 1.5rem;
-  margin-bottom: 3rem;
 
   &--step {
     @include govuk-media-query($from: desktop) {
@@ -41,6 +40,6 @@
     border-left: none;
     border-top: var(--border-brand);
     padding-left: 0;
-    padding-top: 1rem;
+    padding-top: 0.5rem;
   }
 }

--- a/app/assets/stylesheets/pros-cons/main.scss
+++ b/app/assets/stylesheets/pros-cons/main.scss
@@ -1,5 +1,5 @@
 .pros_cons {
-  padding: 1.5rem 1.5rem 1rem;
+  padding: 1rem 1rem 1rem;
   background: var(--grey-4);
   border-top: var(--border-brand);
   margin-top: 2rem;
@@ -9,7 +9,7 @@
   }
 
   &--header {
-    margin-top: 3.25rem;
+    margin-top: 2.25rem;
   }
 
   &__heading {

--- a/app/assets/stylesheets/pros-cons/main.scss
+++ b/app/assets/stylesheets/pros-cons/main.scss
@@ -1,5 +1,5 @@
 .pros_cons {
-  padding: 1rem 1rem 1rem;
+  padding: 1rem;
   background: var(--grey-4);
   border-top: var(--border-brand);
   margin-top: 2rem;

--- a/app/assets/stylesheets/share-link/main.scss
+++ b/app/assets/stylesheets/share-link/main.scss
@@ -17,7 +17,7 @@
   @media (min-width: 641px) {
     position: relative;
     margin-top: -5.7rem;
-    padding: 1rem;
+    padding: 0.9rem;
     top: 0;
   }
 }

--- a/app/assets/stylesheets/share-link/main.scss
+++ b/app/assets/stylesheets/share-link/main.scss
@@ -17,7 +17,7 @@
   @media (min-width: 641px) {
     position: relative;
     margin-top: -5.7rem;
-    padding: 0.9rem;
+    padding: .9rem;
     top: 0;
   }
 }

--- a/app/assets/stylesheets/summary-areas/main.scss
+++ b/app/assets/stylesheets/summary-areas/main.scss
@@ -43,7 +43,7 @@
 
   &__concerning {
     box-sizing: border-box;
-    padding: 1.5rem 1.5rem 2rem;
+    padding: 1rem 1rem 1.5rem;
     background: var(--grey-4);
 
     &__heading {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,16 +6,16 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
-    <%= tag :meta, property: 'og:image', content: asset_path('images/govuk-opengraph-image.png') %>
-    <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
+    <%= tag :meta, name: "viewport", content: "width=device-width, initial-scale=1" %>
+    <%= tag :meta, property: "og:image", content: asset_path("images/govuk-opengraph-image.png") %>
+    <%= tag :meta, name: "theme-color", content: "#0b0c0c" %>
 
-    <%= favicon_link_tag asset_path('images/favicon.ico') %>
-    <%= favicon_link_tag asset_path('images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-    <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+    <%= favicon_link_tag asset_path("images/favicon.ico") %>
+    <%= favicon_link_tag asset_path("images/govuk-mask-icon.svg"), rel: "mask-icon", type: "image/svg", color: "#0b0c0c" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon.png"), rel: "apple-touch-icon", type: "image/png" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon-152x152.png"), rel: "apple-touch-icon", type: "image/png", size: "152x152" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon-167x167.png"), rel: "apple-touch-icon", type: "image/png", size: "167x167" %>
+    <%= favicon_link_tag asset_path("images/govuk-apple-touch-icon-180x180.png"), rel: "apple-touch-icon", type: "image/png", size: "180x180" %>
 
     <%= javascript_include_tag "application", defer: true %>
     <%= stylesheet_link_tag "application" %>
@@ -31,7 +31,7 @@
 
   <body class="govuk-template__body">
     <script>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+      document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");
     </script>
 
     <!-- Google Tag Manager (noscript) -->

--- a/app/views/pages/collaborative-law.html.erb
+++ b/app/views/pages/collaborative-law.html.erb
@@ -224,8 +224,8 @@
 </section>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('page_title.mediation'), professional_mediation_path),
-  govuk_link_to(t('page_title.negotiation'), negotiating_between_parents_path),
-  govuk_link_to(t('page_title.lawyer_negotiation'), lawyer_negotiation_path),
-  govuk_link_to(t('page_title.court'), going_to_court_path) ]
+  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
+  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
+  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
+  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path) ]
 %>

--- a/app/views/pages/collaborative-law.html.erb
+++ b/app/views/pages/collaborative-law.html.erb
@@ -1,6 +1,6 @@
 <section class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
+    <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
 
     <p class="govuk-body-lead">Collaborative lawyers work with you and the other parent to resolve your issues out of
       court. You each hire a lawyer then all meet to negotiate face-to-face.</p>
@@ -105,7 +105,7 @@
               expensive so ask for a quote or see if they offer a fixed fee. Some lawyers give free 30-minute
               consultations.</p>
           </div>
-          <%= govuk_button_to 'Find a collaborative lawyer', 'https://resolution.org.uk/find-a-law-professional/' %>
+          <%= govuk_button_to "Find a collaborative lawyer", "https://resolution.org.uk/find-a-law-professional/" %>
         </div>
         <div class="cost govuk-grid-column-one-third">
           <h4 class="cost__heading govuk-heading-s">Lawyer rates (per hour)</h4>
@@ -214,9 +214,9 @@
         <div class="govuk-grid-column-two-thirds">
           <h2 class="area_links__heading govuk-heading-l">Collaborative law resources</h2>
           <p class="govuk-body">Read more about
-            the <%= govuk_link_to 'collaborative law process', 'https://resolution.org.uk/looking-for-help/splitting-up/your-process-options-for-divorce-and-dissolution/the-collaborative-process/' %></p>
+            the <%= govuk_link_to "collaborative law process", "https://resolution.org.uk/looking-for-help/splitting-up/your-process-options-for-divorce-and-dissolution/the-collaborative-process/" %></p>
           <p class="govuk-body">
-            <%= govuk_link_to 'Find a collaborative lawyer', 'https://resolution.org.uk/find-a-law-professional/' %></p>
+            <%= govuk_link_to "Find a collaborative lawyer", "https://resolution.org.uk/find-a-law-professional/" %></p>
         </div>
       </div>
     </div>
@@ -224,8 +224,8 @@
 </section>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
-  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
-  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
-  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path) ]
+  govuk_link_to(t("pages.professional-mediation.title"), professional_mediation_path),
+  govuk_link_to(t("pages.negotiating-between-parents.title"), negotiating_between_parents_path),
+  govuk_link_to(t("pages.lawyer-negotiation.title"), lawyer_negotiation_path),
+  govuk_link_to(t("pages.going-to-court.title"), going_to_court_path) ]
 %>

--- a/app/views/pages/emotional-support.html.erb
+++ b/app/views/pages/emotional-support.html.erb
@@ -20,18 +20,18 @@
         <p class="govuk-body">The following are examples of helpful forums:</p>
 
         <ul class="govuk-list govuk-list--bullet">
-          <li><%= govuk_link_to 'Click', 'https://click.clickrelationships.org/home/parenting-apart/' %></li>
-          <li><%= govuk_link_to 'Dad.info', 'https://www.dad.info/forum/index' %></li>
-          <li><%= govuk_link_to 'Mumsnet', 'https://www.mumsnet.com/Talk' %></li>
-          <li><%= govuk_link_to 'Wikivorce', 'https://www.wikivorce.com/divorce/About-Us.html' %></li>
-          <li><%= govuk_link_to 'Gingerbread', 'https://www.gingerbread.org.uk/' %></li>
+          <li><%= govuk_link_to "Click", "https://click.clickrelationships.org/home/parenting-apart/" %></li>
+          <li><%= govuk_link_to "Dad.info", "https://www.dad.info/forum/index" %></li>
+          <li><%= govuk_link_to "Mumsnet", "https://www.mumsnet.com/Talk" %></li>
+          <li><%= govuk_link_to "Wikivorce", "https://www.wikivorce.com/divorce/About-Us.html" %></li>
+          <li><%= govuk_link_to "Gingerbread", "https://www.gingerbread.org.uk/" %></li>
         </ul>
       </section>
       <section id="emotional-support-offline" class="SectionArea">
         <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Find a group near you</h3>
         <p class="govuk-body">Look for a
-          <%= govuk_link_to 'family meet-up group', 'https://www.meetup.com/find/parents-family/' %> or
-          <%= govuk_link_to 'single parents network', 'https://www.meetup.com/find/?allMeetups=false&keywords=single+parent+support&radius=50&userFreeform=London%2C+United+Kingdom&mcId=z1012717&mcName=London%2C+England%2C+GB&sort=default&eventFilter=mysugg' %>
+          <%= govuk_link_to "family meet-up group", "https://www.meetup.com/find/parents-family/" %> or
+          <%= govuk_link_to "single parents network", "https://www.meetup.com/find/?allMeetups=false&keywords=single+parent+support&radius=50&userFreeform=London%2C+United+Kingdom&mcId=z1012717&mcName=London%2C+England%2C+GB&sort=default&eventFilter=mysugg" %>
           in your area. Both work in the same way as forums but the focus is usually on meeting face to face.</p>
       </section>
     </section>
@@ -60,10 +60,10 @@
         <li>the effect disputes have on your children</li>
         <li>why your relationship with the other parent ended</li>
       </ul>
-      <p class="govuk-body"><%= govuk_link_to 'Contact the Samaritans', 'https://www.samaritans.org/how-we-can-help-you/contact-us' %>
+      <p class="govuk-body"><%= govuk_link_to "Contact the Samaritans", "https://www.samaritans.org/how-we-can-help-you/contact-us" %>
         if you need to speak to someone urgently.</p>
       <p class="govuk-body">
-        <%= govuk_button_to 'Find a counsellor', 'https://www.counselling-directory.org.uk/adv-search.html' %>
+        <%= govuk_button_to "Find a counsellor", "https://www.counselling-directory.org.uk/adv-search.html" %>
       </p>
     </div>
 
@@ -80,19 +80,19 @@
     <div class="govuk-grid-column-two-thirds govuk-!-margin-top-3">
       <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Parenting advice</h3>
       <p class="govuk-body">The
-        <%= govuk_link_to 'Separated Parents Information Programme (SPIP)', 'https://www.cafcass.gov.uk/grown-ups/parents-and-carers/divorce-and-separation/separated-parents-information-programme/' %>
+        <%= govuk_link_to "Separated Parents Information Programme (SPIP)", "https://www.cafcass.gov.uk/grown-ups/parents-and-carers/divorce-and-separation/separated-parents-information-programme/" %>
         helps you understand how to put your children first and manage disputes with the other parent.</p>
 
       <p class="govuk-body">A judge may direct you to attend a SPIP if you take your case to court. You won't go to the
         same meeting as the other parent.</p>
       <p class="govuk-body">There are similar programmes in
-        <%= govuk_link_to 'Wales', 'https://gov.wales/cafcass-cymru/family-separation' %> and
-        <%= govuk_link_to 'Scotland', 'https://www.relationships-scotland.org.uk/family-support/parenting-apart-groups' %>
+        <%= govuk_link_to "Wales", "https://gov.wales/cafcass-cymru/family-separation" %> and
+        <%= govuk_link_to "Scotland", "https://www.relationships-scotland.org.uk/family-support/parenting-apart-groups" %>
         .
       </p>
 
       <p class="govuk-body">
-        <%= govuk_button_to 'Search for a SPIP', 'https://www.cafcass.gov.uk/grown-ups/parents-and-carers/resources-parents-carers/' %>
+        <%= govuk_button_to "Search for a SPIP", "https://www.cafcass.gov.uk/grown-ups/parents-and-carers/resources-parents-carers/" %>
       </p>
     </div>
 
@@ -115,7 +115,7 @@
         the best interests of your children.</p>
       <p class="govuk-body">The Children and Family Court Advisory and Support Service (Cafcass) has more information on
         what you need to do
-        to <%= govuk_link_to 'become emotionally ready', 'https://www.cafcass.gov.uk/grown-ups/parents-and-carers/divorce-and-separation/childs-voice-separation/' %>
+        to <%= govuk_link_to "become emotionally ready", "https://www.cafcass.gov.uk/grown-ups/parents-and-carers/divorce-and-separation/childs-voice-separation/" %>
         .</p>
     </section>
   </div>
@@ -128,17 +128,17 @@
         <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
           <section id="emotional-support-resources" class="ResourcesSection">
             <h2 class="govuk-heading-l">Getting emotional support resources</h2>
-            <p class="govuk-body"><%= govuk_link_to 'Find out more about counselling', 'https://www.counselling-directory.org.uk/separation.html' %></p>
+            <p class="govuk-body"><%= govuk_link_to "Find out more about counselling", "https://www.counselling-directory.org.uk/separation.html" %></p>
             <p class="govuk-body">Relate has a
-              <%= govuk_link_to 'free online chat service', 'https://www.relate.org.uk/relationship-help/talk-someone/live-chat-counsellor' %>
+              <%= govuk_link_to "free online chat service", "https://www.relate.org.uk/relationship-help/talk-someone/live-chat-counsellor" %>
               . Sessions last around 25 minutes.</p>
 
             <p class="govuk-body">Relate also has a
-              <%= govuk_link_to 'telephone service', 'https://www.relate.org.uk/relationship-help/talk-someone/telephone-counselling' %>
+              <%= govuk_link_to "telephone service", "https://www.relate.org.uk/relationship-help/talk-someone/telephone-counselling" %>
               that costs &pound;55 per hour.</p>
 
             <p class="govuk-body">
-              <%= govuk_link_to 'Getting it right for children', 'https://click.clickrelationships.org/content/parenting-apart/course-getting-it-right-for-children/' %>
+              <%= govuk_link_to "Getting it right for children", "https://click.clickrelationships.org/content/parenting-apart/course-getting-it-right-for-children/" %>
               is a free programme which uses real life situations to show how things can go wrong - and how you can do them
               better.</p>
           </section>
@@ -149,6 +149,6 @@
 </section>
 
 <%= render "shared/prepare_links", links: [
-  govuk_link_to(t('pages.involving-children.title'), involving_children_path),
-  govuk_link_to(t('pages.parental-responsibility.title'), parental_responsibility_path)]
+  govuk_link_to(t("pages.involving-children.title"), involving_children_path),
+  govuk_link_to(t("pages.parental-responsibility.title"), parental_responsibility_path)]
 %>

--- a/app/views/pages/emotional-support.html.erb
+++ b/app/views/pages/emotional-support.html.erb
@@ -149,6 +149,6 @@
 </section>
 
 <%= render "shared/prepare_links", links: [
-  govuk_link_to(t('page_title.involving'), involving_children_path),
-  govuk_link_to(t('page_title.responsibility'), parental_responsibility_path)]
+  govuk_link_to(t('pages.involving-children.title'), involving_children_path),
+  govuk_link_to(t('pages.parental-responsibility.title'), parental_responsibility_path)]
 %>

--- a/app/views/pages/going-to-court-other-parent.html.erb
+++ b/app/views/pages/going-to-court-other-parent.html.erb
@@ -8,11 +8,11 @@
       <h2 class="area_links__heading govuk-heading-l">Before they've applied</h2>
       <p class="govuk-body">
         Before the other parent can apply for a court order about your child arrangements, they must show they've attended a meeting about mediation, <%= govuk_link_to "except in certain cases", "https://apply-to-court-about-child-arrangements.service.justice.gov.uk/about/miam_exemptions" %>.
-        This is called a MIAM or Mediation Information and Assessment Meeting. The mediator will <%= govuk_link_to "invite you to a meeting too", "/professional-mediation-other-parent" %>.
+        This is called a MIAM or Mediation Information and Assessment Meeting. The mediator will <%= govuk_link_to "invite you to a meeting too", professional_mediation_other_parent_path %>.
       </p>
       <p class="govuk-body">
         There's usually a better outcome for children and parents if you can reach an agreement without going to court.
-        So if there are no safety concerns, you should talk to the other parent about different options such as <%= govuk_link_to "negotiation", "/negotiating-between-parents" %> or <%= govuk_link_to "professional mediation", "/professional-mediation" %>.
+        So if there are no safety concerns, you should talk to the other parent about different options such as <%= govuk_link_to "negotiation", negotiating_between_parents_path %> or <%= govuk_link_to "professional mediation", professional_mediation_path %>.
       </p>
     </section>
 

--- a/app/views/pages/going-to-court-other-parent.html.erb
+++ b/app/views/pages/going-to-court-other-parent.html.erb
@@ -95,9 +95,9 @@
 </section>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('page_title.mediation'), professional_mediation_path),
-  govuk_link_to(t('page_title.negotiation'), negotiating_between_parents_path),
-  govuk_link_to(t('page_title.lawyer_negotiation'), lawyer_negotiation_path),
-  govuk_link_to(t('page_title.collaborative'), collaborative_law_path),
-  govuk_link_to(t('page_title.court'), going_to_court_path) ]
+  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
+  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
+  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
+  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path),
+  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path) ]
 %>

--- a/app/views/pages/going-to-court-other-parent.html.erb
+++ b/app/views/pages/going-to-court-other-parent.html.erb
@@ -34,7 +34,7 @@
       <p class="govuk-body">You'll have to <%= govuk_link_to "attend court", "https://www.gov.uk/represent-yourself-in-court" %> for any hearings. You can ask to appear in a different room in court from your ex-partner.</p>
       <p class="govuk-body">At the first hearing the judge will see if there's still a chance you can reach an agreement with the other parent.</p>
       <p class="govuk-body">They may ask you to try again to reach an agreement, for example by going to a meeting with a mediator.</p>
-      <p class="govuk-body">You may have to go on a course called a <%= govuk_link_to "'Separated Parents Information Programme'", "https://www.cafcass.gov.uk/grown-ups/parents-and-carers/divorce-and-separation/separated-parents-information-programme/" %>.</p>
+      <p class="govuk-body">You may have to go on a course called a <%= govuk_link_to "‘Separated Parents Information Programme’", "https://www.cafcass.gov.uk/grown-ups/parents-and-carers/divorce-and-separation/separated-parents-information-programme/" %>.</p>
       <p class="govuk-body">The court can ask Cafcass to provide a report on your case to help decide what's best for the child. The Cafcass officer may ask your child about their feelings. You'll get a copy of the report when it's written.</p>
       <p class="govuk-body">If you cannot agree, there may be further court hearings that you need to attend and you may need to give evidence.</p>
       <p class="govuk-body">The judge or magistrate will always put the welfare of children first when making the decision about child arrangements. They will think about the:</p>
@@ -95,9 +95,9 @@
 </section>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
-  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
-  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
-  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path),
-  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path) ]
+  govuk_link_to(t("pages.professional-mediation.title"), professional_mediation_path),
+  govuk_link_to(t("pages.negotiating-between-parents.title"), negotiating_between_parents_path),
+  govuk_link_to(t("pages.lawyer-negotiation.title"), lawyer_negotiation_path),
+  govuk_link_to(t("pages.collaborative-law.title"), collaborative_law_path),
+  govuk_link_to(t("pages.going-to-court.title"), going_to_court_path) ]
 %>

--- a/app/views/pages/going-to-court.html.erb
+++ b/app/views/pages/going-to-court.html.erb
@@ -153,23 +153,22 @@
             <h3 class="govuk-heading-s">Hire a lawyer</h3>
             <p class="govuk-body">A lawyer can be expensive but they'll handle the legal aspects of the case and represent you in court.</p>
             <p class="govuk-body">They may try and negotiate a deal out of court with the other parent or recommend you move to step 2 straight away.</p>
-            <p class="govuk-body">Your lawyer and the other parent's lawyer will then contact each other so they can
-              plan for your first collaborative meeting.</p>
             <p class="govuk-body"><%= govuk_link_to "Find a legal adviser", "https://solicitors.lawsociety.org.uk/" %></p>
             <h3 class="govuk-heading-s">Represent yourself</h3>
             <p class="govuk-body">You may choose to represent yourself because you'd prefer to speak to the judge directly or because you can't afford the legal fees.</p>
             <p class="govuk-body">If you can't afford legal representation, you can still ask a lawyer for advice at any time during the court process.</p>
-            <p class="govuk-body">GOV.UK has more information on <%= govuk_link_to 'how to represent yourself in court.', 'https://www.gov.uk/represent-yourself-in-court' %>
+            <p class="govuk-body">GOV.UK has more information on <%= govuk_link_to "how to represent yourself in court", 'https://www.gov.uk/represent-yourself-in-court' %>.
 
-            <p class="govuk-body"><%= govuk_link_to 'Support Through Court', 'https://www.supportthroughcourt.org/' %> provides help for every stage of the court process for those without a lawyer.
-            <p class="govuk-body"><%= govuk_link_to 'Find a free legal advice clinic', 'https://www.lawworks.org.uk/legal-advice-individuals/find-legal-advice-clinic-near-you' %>
+            <p class="govuk-body"><%= govuk_link_to "Support Through Court", "https://www.supportthroughcourt.org/" %> provides help for every stage of the court process for those without a lawyer.
+            <p class="govuk-body"><%= govuk_link_to "Find a free legal advice clinic", "https://www.lawworks.org.uk/legal-advice-individuals/find-legal-advice-clinic-near-you" %>
           </div>
         </div>
         <div class="cost govuk-grid-column-one-third">
           <h4 class="cost__heading govuk-heading-s">Lawyer rates (per hour)</h4>
           <p class="cost__amount govuk-heading-l"><strong>&pound;110 - &pound;410</strong></p>
           <p class="govuk-body-xs">Fees may vary depending on your location and the experience of the lawyer. How long
-            you need will depend on your situation.</p>
+            you need will depend on your situation. Some lawyers offer free 30-minute consultations or fixed fees.
+            You can also <%= govuk_link_to "check if you can get free legal help", "https://weareadvocate.org.uk/apply-for-help.html" %>.</p>
         </div>
       </div>
     </div>

--- a/app/views/pages/going-to-court.html.erb
+++ b/app/views/pages/going-to-court.html.erb
@@ -189,7 +189,7 @@
           </h2>
 
           <div class="step__content  govuk-govspeak gv-s-prose">
-            <p class="govuk-body">Before applying for a court order you must attend a <%= govuk_link_to "MIAM" professional_mediation_path %>, unless <%= govuk_link_to "you're exempt","https://apply-to-court-about-child-arrangements.service.justice.gov.uk/about/miam_exemptions" %>.</p>
+            <p class="govuk-body">Before applying for a court order you must attend a <%= govuk_link_to "MIAM", professional_mediation_path %>, unless <%= govuk_link_to "you're exempt","https://apply-to-court-about-child-arrangements.service.justice.gov.uk/about/miam_exemptions" %>.</p>
             <p class="govuk-body">The MIAM will assess whether mediation is right for you and if you can agree arrangements out of court.</p>
             <p class="govuk-body">You will need to <%= govuk_link_to "find a mediator", "https://www.familymediationcouncil.org.uk/find-local-mediator/" %> to book a MIAM.</p>
             <p class="govuk-body">Only authorised mediators can carry out a MIAM. Check with the mediator before you book.</p>

--- a/app/views/pages/going-to-court.html.erb
+++ b/app/views/pages/going-to-court.html.erb
@@ -157,7 +157,7 @@
             <h3 class="govuk-heading-s">Represent yourself</h3>
             <p class="govuk-body">You may choose to represent yourself because you'd prefer to speak to the judge directly or because you can't afford the legal fees.</p>
             <p class="govuk-body">If you can't afford legal representation, you can still ask a lawyer for advice at any time during the court process.</p>
-            <p class="govuk-body">GOV.UK has more information on <%= govuk_link_to "how to represent yourself in court", 'https://www.gov.uk/represent-yourself-in-court' %>.
+            <p class="govuk-body">GOV.UK has more information on <%= govuk_link_to "how to represent yourself in court", "https://www.gov.uk/represent-yourself-in-court" %>.
 
             <p class="govuk-body"><%= govuk_link_to "Support Through Court", "https://www.supportthroughcourt.org/" %> provides help for every stage of the court process for those without a lawyer.
             <p class="govuk-body"><%= govuk_link_to "Find a free legal advice clinic", "https://www.lawworks.org.uk/legal-advice-individuals/find-legal-advice-clinic-near-you" %>
@@ -189,9 +189,9 @@
           </h2>
 
           <div class="step__content  govuk-govspeak gv-s-prose">
-            <p class="govuk-body">Before applying for a court order you must attend a <%= govuk_link_to 'MIAM', professional_mediation_path %>, unless <%= govuk_link_to "you're exempt","https://apply-to-court-about-child-arrangements.service.justice.gov.uk/about/miam_exemptions" %>.</p>
+            <p class="govuk-body">Before applying for a court order you must attend a <%= govuk_link_to "MIAM" professional_mediation_path %>, unless <%= govuk_link_to "you're exempt","https://apply-to-court-about-child-arrangements.service.justice.gov.uk/about/miam_exemptions" %>.</p>
             <p class="govuk-body">The MIAM will assess whether mediation is right for you and if you can agree arrangements out of court.</p>
-            <p class="govuk-body">You will need to <%= govuk_link_to 'find a mediator', 'https://www.familymediationcouncil.org.uk/find-local-mediator/' %> to book a MIAM.</p>
+            <p class="govuk-body">You will need to <%= govuk_link_to "find a mediator", "https://www.familymediationcouncil.org.uk/find-local-mediator/" %> to book a MIAM.</p>
             <p class="govuk-body">Only authorised mediators can carry out a MIAM. Check with the mediator before you book.</p>
           </div>
         </div>
@@ -303,8 +303,8 @@
 </section>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
-  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
-  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
-  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path)]
+  govuk_link_to(t("pages.professional-mediation.title"), professional_mediation_path),
+  govuk_link_to(t("pages.negotiating-between-parents.title"), negotiating_between_parents_path),
+  govuk_link_to(t("pages.lawyer-negotiation.title"), lawyer_negotiation_path),
+  govuk_link_to(t("pages.collaborative-law.title"), collaborative_law_path)]
 %>

--- a/app/views/pages/going-to-court.html.erb
+++ b/app/views/pages/going-to-court.html.erb
@@ -189,7 +189,7 @@
           </h2>
 
           <div class="step__content  govuk-govspeak gv-s-prose">
-            <p class="govuk-body">Before applying for a court order you must attend a <%= govuk_link_to "MIAM", professional_mediation_path %>, unless <%= govuk_link_to "you're exempt","https://apply-to-court-about-child-arrangements.service.justice.gov.uk/about/miam_exemptions" %>.</p>
+            <p class="govuk-body">Before applying for a court order you must attend a <%= govuk_link_to "MIAM", professional_mediation_path %>, unless <%= govuk_link_to "you're exempt", "https://apply-to-court-about-child-arrangements.service.justice.gov.uk/about/miam_exemptions" %>.</p>
             <p class="govuk-body">The MIAM will assess whether mediation is right for you and if you can agree arrangements out of court.</p>
             <p class="govuk-body">You will need to <%= govuk_link_to "find a mediator", "https://www.familymediationcouncil.org.uk/find-local-mediator/" %> to book a MIAM.</p>
             <p class="govuk-body">Only authorised mediators can carry out a MIAM. Check with the mediator before you book.</p>

--- a/app/views/pages/going-to-court.html.erb
+++ b/app/views/pages/going-to-court.html.erb
@@ -304,8 +304,8 @@
 </section>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('page_title.mediation'), professional_mediation_path),
-  govuk_link_to(t('page_title.negotiation'), negotiating_between_parents_path),
-  govuk_link_to(t('page_title.lawyer_negotiation'), lawyer_negotiation_path),
-  govuk_link_to(t('page_title.collaborative'), collaborative_law_path)]
+  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
+  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
+  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
+  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path)]
 %>

--- a/app/views/pages/homepage.html.erb
+++ b/app/views/pages/homepage.html.erb
@@ -6,9 +6,9 @@
       or custody) with the other parent. For example, you may need to decide where your children will live or rearrange
       the times they see you.</p>
 
-    <%= govuk_inset_text(html_attributes: { lang: "en-GB", data: { demo: true }, aria: { role: 'note' } }) do %>
+    <%= govuk_inset_text(html_attributes: { lang: "en-GB", data: { demo: true }, aria: { role: "note" } }) do %>
       This guide is for parents. There's also
-      <%= govuk_link_to 'help available for grandparents', 'https://www.gov.uk/contact-grandchild-parents-divorce-separate' %>
+      <%= govuk_link_to "help available for grandparents", "https://www.gov.uk/contact-grandchild-parents-divorce-separate" %>
     <% end %>
 
     <p class="govuk-body govuk-!-font-weight-bold">You could get up to &pound;500 towards family mediation</p>
@@ -18,9 +18,7 @@
 
     <p class="govuk-body">
       Find out more about the
-      <%= govuk_link_to 'family mediation voucher scheme',
-                        'https://www.gov.uk/guidance/family-mediation-voucher-scheme?utm_source=CAIT&amp;utm_campaign=mediation_vouchers' %>
-      .
+      <%= govuk_link_to "family mediation voucher scheme", "https://www.gov.uk/guidance/family-mediation-voucher-scheme?utm_source=CAIT&amp;utm_campaign=mediation_vouchers" %>.
     </p>
 
     <p class="govuk-body">This guide contains help on:</p>
@@ -43,7 +41,7 @@
       <article class="summary_area summary_area__Template-" id="card-involving_children" data-slug="" data-block-name="route:involving_children">
         <div class="summary_area__details">
           <h3 class="summary_area__heading govuk-heading-m">
-            <%= govuk_link_to 'Putting your children first', involving_children_path %>
+            <%= govuk_link_to "Putting your children first", involving_children_path %>
           </h3>
           <p class="govuk-body">The needs of your children should come first when you
             make child arrangements with the other parent.</p>
@@ -72,7 +70,7 @@
         </aside>
 
         <p class="summary_area__read-more">
-          <%= govuk_link_to 'Read more about putting your children first', involving_children_path %>
+          <%= govuk_link_to "Read more about putting your children first", involving_children_path %>
         </p>
 
       </article>
@@ -81,7 +79,7 @@
       <article class="summary_area summary_area__Template-" id="card-parental_responsibility" data-slug="" data-block-name="route:parental_responsibility">
         <div class="summary_area__details">
           <h3 class="summary_area__heading govuk-heading-m">
-            <%= govuk_link_to 'Your parental responsibility', parental_responsibility_path %>
+            <%= govuk_link_to "Your parental responsibility", parental_responsibility_path %>
           </h3>
           <p class="summary_area__lede govuk-body">Parental responsibility is a term that means you have
             legal rights and duties relating to your children's upbringing. </p>
@@ -110,14 +108,14 @@
           </div>
         </aside>
         <p class="summary_area__read-more">
-          <%= govuk_link_to 'Read more about your parental responsibility', parental_responsibility_path %>
+          <%= govuk_link_to "Read more about your parental responsibility", parental_responsibility_path %>
         </p>
       </article>
 
       <article class="summary_area summary_area__Template-" id="card-emotional_support" data-slug="" data-block-name="route:emotional_support">
         <div class="summary_area__details">
           <h3 class="summary_area__heading govuk-heading-m">
-            <%= govuk_link_to 'Getting emotional support', emotional_support_path %>
+            <%= govuk_link_to "Getting emotional support", emotional_support_path %>
           </h3>
           <p class="govuk-body">Emotional support can help you get through the stress of making child arrangements.</p>
           <p class="govuk-body">You're more likely to reach an agreement if you're emotionally ready and know where to
@@ -136,7 +134,7 @@
           </div>
         </aside>
         <p class="summary_area__read-more">
-          <%= govuk_link_to 'Read more about getting emotional support', emotional_support_path %>
+          <%= govuk_link_to "Read more about getting emotional support", emotional_support_path %>
         </p>
       </article>
     </section>
@@ -146,7 +144,7 @@
       <article class="summary_area summary_area__Template-" id="card-negotiating_between_parents" data-slug="" data-block-name="route:negotiating_between_parents">
         <div class="summary_area__details">
           <h3 class="summary_area__heading govuk-heading-m">
-            <%= govuk_link_to 'Negotiation tools and services', negotiating_between_parents_path %>
+            <%= govuk_link_to "Negotiation tools and services", negotiating_between_parents_path %>
           </h3>
           <p class="govuk-body">If there are no safety concerns, the cheapest and
             easiest way to make arrangements is to negotiate with the other parent. There are free tools and services
@@ -215,7 +213,7 @@
           </div>
         </aside>
         <p class="summary_area__read-more">
-          <%= govuk_link_to 'Read more about negotiation tools and services', negotiating_between_parents_path %>
+          <%= govuk_link_to "Read more about negotiation tools and services", negotiating_between_parents_path %>
         </p>
       </article>
 
@@ -223,7 +221,7 @@
       <article class="summary_area summary_area__Template-" id="card-professional_mediation" data-slug="" data-block-name="route:professional_mediation">
         <div class="summary_area__details">
           <h3 class="summary_area__heading govuk-heading-m">
-            <%= govuk_link_to 'Professional mediation', professional_mediation_path %>
+            <%= govuk_link_to "Professional mediation", professional_mediation_path %>
           </h3>
           <p class="summary_area__lede govuk-body">Mediation sessions are run by professionals who help
             you try to reach an agreement without going to court. It isn't relationship counselling and you don't have
@@ -293,14 +291,14 @@
           </div>
         </aside>
         <p class="summary_area__read-more">
-          <%= govuk_link_to 'Read more about professional mediation', professional_mediation_path %>
+          <%= govuk_link_to "Read more about professional mediation", professional_mediation_path %>
         </p>
       </article>
 
       <article class="summary_area summary_area__Template-" id="card-lawyer_negotiation" data-slug="" data-block-name="route:lawyer_negotiation">
         <div class="summary_area__details">
           <h3 class="summary_area__heading govuk-heading-m">
-            <%= govuk_link_to 'Lawyer negotiation', lawyer_negotiation_path %>
+            <%= govuk_link_to "Lawyer negotiation", lawyer_negotiation_path %>
           </h3>
           <p class="summary_area__lede govuk-body">You don't have to deal directly with the other parent
             if you choose this option. You hire a lawyer to negotiate arrangements for you.</p>
@@ -362,14 +360,14 @@
           </div>
         </aside>
         <p class="summary_area__read-more">
-          <%= govuk_link_to 'Read more about lawyer negotiation', lawyer_negotiation_path %>
+          <%= govuk_link_to "Read more about lawyer negotiation", lawyer_negotiation_path %>
         </p>
       </article>
 
       <article class="summary_area summary_area__Template-" id="card-collaborative_law" data-slug="" data-block-name="route:collaborative_law">
         <div class="summary_area__details">
           <h3 class="summary_area__heading govuk-heading-m">
-            <%= govuk_link_to 'Collaborative law', collaborative_law_path %>
+            <%= govuk_link_to "Collaborative law", collaborative_law_path %>
           </h3>
           <p class="summary_area__lede govuk-body">Collaborative lawyers work with you and the other
             parent to resolve your issues out of court. You each hire a lawyer then all meet to negotiate
@@ -438,7 +436,7 @@
           </div>
         </aside>
         <p class="summary_area__read-more">
-          <%= govuk_link_to 'Read more about collaborative law', collaborative_law_path %>
+          <%= govuk_link_to "Read more about collaborative law" collaborative_law_path %>
         </p>
       </article>
 
@@ -446,7 +444,7 @@
       <article class="summary_area summary_area__Template-" id="card-going_to_court" data-slug="" data-block-name="route:going_to_court">
         <div class="summary_area__details">
           <h3 class="summary_area__heading govuk-heading-m">
-            <%= govuk_link_to 'Going to court', going_to_court_path %>
+            <%= govuk_link_to "Going to court", going_to_court_path %>
           </h3>
           <p class="summary_area__lede govuk-body">You'll need to go to court if you've tried other
             suitable options and still can't agree arrangements, or you're worried about the welfare of you or your
@@ -513,7 +511,7 @@
           </div>
         </aside>
         <p class="summary_area__read-more">
-          <%= govuk_link_to 'Read more about going to court', going_to_court_path %>
+          <%= govuk_link_to "Read more about going to court", going_to_court_path %>
         </p>
       </article>
     </section>

--- a/app/views/pages/homepage.html.erb
+++ b/app/views/pages/homepage.html.erb
@@ -436,7 +436,7 @@
           </div>
         </aside>
         <p class="summary_area__read-more">
-          <%= govuk_link_to "Read more about collaborative law" collaborative_law_path %>
+          <%= govuk_link_to "Read more about collaborative law", collaborative_law_path %>
         </p>
       </article>
 

--- a/app/views/pages/involving-children.html.erb
+++ b/app/views/pages/involving-children.html.erb
@@ -15,8 +15,7 @@
         needs of your children as they grow older.</p>
 
       <p class="govuk-body">
-        <%= govuk_link_to 'Find out more about involving your children',
-                          'https://www.cafcass.gov.uk/grown-ups/parents-and-carers/divorce-and-separation/childs-voice-separation/' %>
+        <%= govuk_link_to "Find out more about involving your children", "https://www.cafcass.gov.uk/grown-ups/parents-and-carers/divorce-and-separation/childs-voice-separation/" %>
       </p>
     </section>
 
@@ -26,11 +25,10 @@
         and the other parent, if it's safe to do so.</p>
 
       <p class="govuk-body">
-        <%= govuk_link_to 'Research shows',
-                          'https://click.clickrelationships.org/content/parenting-apart/two-parents-two-homes' %> most
+        <%= govuk_link_to "Research shows", "https://click.clickrelationships.org/content/parenting-apart/two-parents-two-homes" %> most
         children think the parent who doesn't live with them is still an important part of their family.</p>
 
-      <p class="govuk-body">You can use a <%= govuk_link_to 'child contact centre', 'https://naccc.org.uk/' %> if you
+      <p class="govuk-body">You can use a <%= govuk_link_to "child contact centre", "https://naccc.org.uk/" %> if you
         don't live with your children and can't find somewhere to see them. There are around 350 across England and
         Wales.
       </p>
@@ -40,7 +38,7 @@
 
       <p class="govuk-body">In the letter you should ask for regular contact, suggesting possible days or times. If they
         refuse, ask whether they would consider
-        <%= govuk_link_to 'mediation', professional_mediation_path %>
+        <%= govuk_link_to "mediation", professional_mediation_path %>
         to resolve the issue.</p>
 
       <p class="govuk-body">Don't forget to send your letter by recorded delivery so you know the other parent has
@@ -53,11 +51,11 @@
 
       <h3 class="govuk-heading-s">Counselling</h3>
       <p class="govuk-body">Many schools provide support but some children might need further help from a
-        <%= govuk_link_to 'counsellor', 'https://www.counselling-directory.org.uk/childrelatedissues.html' %>. The type
+        <%= govuk_link_to "counsellor", "https://www.counselling-directory.org.uk/childrelatedissues.html" %>. The type
         of counselling varies depending on the child's age and if they have learning difficulties.</p>
 
       <h3 class="govuk-heading-s">Support online</h3>
-      <p class="govuk-body"><%= govuk_link_to 'Voices in the Middle', 'https://www.voicesinthemiddle.com/' %> is a
+      <p class="govuk-body"><%= govuk_link_to "Voices in the Middle", "https://www.voicesinthemiddle.com/" %> is a
         website that has advice from young people in a similar situation. There's a guide to further help if your
         children want it.</p>
     </section>
@@ -68,23 +66,23 @@
       </h2>
       <p class="govuk-body">In some situations it may not be in the child's best interests for parents to work out child
         arrangements. You'll probably need
-        to <%= govuk_link_to 'go to court', '/going-to-court' %>
+        to <%= govuk_link_to "go to court", "/going-to-court" %>
         if you're worried about the welfare of you or your children.
       </p>
       <p class="govuk-body">You should
-        <%= govuk_link_to 'report child abuse', 'https://www.gov.uk/report-child-abuse' %> or
-        <%= govuk_link_to 'domestic abuse', 'https://www.gov.uk/report-domestic-abuse' %>
+        <%= govuk_link_to "report child abuse", "https://www.gov.uk/report-child-abuse" %> or
+        <%= govuk_link_to "domestic abuse", "https://www.gov.uk/report-domestic-abuse" %>
         if you have any concerns.
       </p>
       <p class="govuk-body">Read more about the
-        <%= govuk_link_to 'signs of child abuse', 'https://www.nspcc.org.uk/what-is-child-abuse/types-of-abuse/' %> and
-        <%= govuk_link_to 'domestic abuse', 'http://www.refuge.org.uk/get-help-now/recognising-abuse/' %>.
+        <%= govuk_link_to "signs of child abuse", "https://www.nspcc.org.uk/what-is-child-abuse/types-of-abuse/" %> and
+        <%= govuk_link_to "domestic abuse", "http://www.refuge.org.uk/get-help-now/recognising-abuse/" %>.
       </p>
     </section>
   </div>
 </div>
 
 <%= render "shared/prepare_links", links: [
-  govuk_link_to(t('pages.parental-responsibility.title'), parental_responsibility_path),
-  govuk_link_to(t('pages.emotional-support.title'), emotional_support_path)]
+  govuk_link_to(t("pages.parental-responsibility.title"), parental_responsibility_path),
+  govuk_link_to(t("pages.emotional-support.title"), emotional_support_path)]
 %>

--- a/app/views/pages/involving-children.html.erb
+++ b/app/views/pages/involving-children.html.erb
@@ -66,7 +66,7 @@
       </h2>
       <p class="govuk-body">In some situations it may not be in the child's best interests for parents to work out child
         arrangements. You'll probably need
-        to <%= govuk_link_to "go to court", "/going-to-court" %>
+        to <%= govuk_link_to "go to court", going_to_court_path %>
         if you're worried about the welfare of you or your children.
       </p>
       <p class="govuk-body">You should

--- a/app/views/pages/involving-children.html.erb
+++ b/app/views/pages/involving-children.html.erb
@@ -84,6 +84,6 @@
 </div>
 
 <%= render "shared/prepare_links", links: [
-  govuk_link_to(t('page_title.responsibility'), parental_responsibility_path),
-  govuk_link_to(t('page_title.support'), emotional_support_path)]
+  govuk_link_to(t('pages.parental-responsibility.title'), parental_responsibility_path),
+  govuk_link_to(t('pages.emotional-support.title'), emotional_support_path)]
 %>

--- a/app/views/pages/involving-children.html.erb
+++ b/app/views/pages/involving-children.html.erb
@@ -74,10 +74,11 @@
       <p class="govuk-body">You should
         <%= govuk_link_to 'report child abuse', 'https://www.gov.uk/report-child-abuse' %> or
         <%= govuk_link_to 'domestic abuse', 'https://www.gov.uk/report-domestic-abuse' %>
+        if you have any concerns.
       </p>
       <p class="govuk-body">Read more about the
         <%= govuk_link_to 'signs of child abuse', 'https://www.nspcc.org.uk/what-is-child-abuse/types-of-abuse/' %> and
-        <%= govuk_link_to 'domestic abuse', 'http://www.refuge.org.uk/get-help-now/recognising-abuse/' %>
+        <%= govuk_link_to 'domestic abuse', 'http://www.refuge.org.uk/get-help-now/recognising-abuse/' %>.
       </p>
     </section>
   </div>

--- a/app/views/pages/lawyer-negotiation.html.erb
+++ b/app/views/pages/lawyer-negotiation.html.erb
@@ -116,8 +116,8 @@
 </section>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('page_title.mediation'), professional_mediation_path),
-  govuk_link_to(t('page_title.negotiation'), negotiating_between_parents_path),
-  govuk_link_to(t('page_title.collaborative'), collaborative_law_path),
-  govuk_link_to(t('page_title.court'), going_to_court_path)]
+  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
+  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
+  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path),
+  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path)]
 %>

--- a/app/views/pages/lawyer-negotiation.html.erb
+++ b/app/views/pages/lawyer-negotiation.html.erb
@@ -100,7 +100,7 @@
       approval.</p>
 
     <p class="govuk-body">
-      <%= govuk_button_to 'Find a lawyer', 'https://solicitors.lawsociety.org.uk/' %>
+      <%= govuk_button_to "Find a lawyer", "https://solicitors.lawsociety.org.uk/" %>
     </p>
   </div>
 
@@ -110,14 +110,14 @@
     <p class="govuk-body-xs">Fees may vary depending on your location and the experience of the lawyer. How long you
       need will depend on
       your situation. Some lawyers offer free 30-minute consultations or you can
-      <%= govuk_link_to 'check if you can get free legal help', 'https://www.lawworks.org.uk/legal-advice-individuals' %>.
+      <%= govuk_link_to "check if you can get free legal help", "https://www.lawworks.org.uk/legal-advice-individuals" %>.
     </p>
   </div>
 </section>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
-  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
-  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path),
-  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path)]
+  govuk_link_to(t("pages.professional-mediation.title"), professional_mediation_path),
+  govuk_link_to(t("pages.negotiating-between-parents.title"), negotiating_between_parents_path),
+  govuk_link_to(t("pages.collaborative-law.title"), collaborative_law_path),
+  govuk_link_to(t("pages.going-to-court.title"), going_to_court_path)]
 %>

--- a/app/views/pages/lawyer-negotiation.html.erb
+++ b/app/views/pages/lawyer-negotiation.html.erb
@@ -104,7 +104,7 @@
     </p>
   </div>
 
-  <div class="cost govuk-grid-column-one-third govuk-!-margin-top-4">
+  <div class="cost govuk-grid-column-one-third govuk-!-margin-top-2">
     <h4 class="cost__heading govuk-heading-s">Lawyer rates (per hour)</h4>
     <p class="cost__amount govuk-heading-l"><strong>&pound;110 - &pound;410</strong></p>
     <p class="govuk-body-xs">Fees may vary depending on your location and the experience of the lawyer. How long you

--- a/app/views/pages/negotiating-between-parents.html.erb
+++ b/app/views/pages/negotiating-between-parents.html.erb
@@ -101,7 +101,7 @@
       if you prefer to negotiate by letter or email.</p>
 
     <h2 class="govuk-heading-l">When negotiating may not be suitable</h2>
-    <h3 class="govuk-heading-m">Parenting plan</h3>
+    <h3 class="govuk-heading-m">Child abuse or neglect</h3>
     <p class="govuk-body">You shouldn't make arrangements with the other parent if you think they:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>are abusing your children</li>

--- a/app/views/pages/negotiating-between-parents.html.erb
+++ b/app/views/pages/negotiating-between-parents.html.erb
@@ -68,7 +68,7 @@
     <h2 class="govuk-heading-l">Which tools and services to use</h2>
     <p class="govuk-body">The needs of your children must come first when negotiating arrangements. The following are
       flexible, unless you make them into a
-      <%= govuk_link_to 'consent order', 'https://www.gov.uk/looking-after-children-divorce/if-you-agree' %>.</p>
+      <%= govuk_link_to "consent order", "https://www.gov.uk/looking-after-children-divorce/if-you-agree" %>.</p>
     <p class="govuk-body">Flexible plans are useful if you and the other parent want to change the details as your
       children grow older and their needs change.</p>
 
@@ -84,20 +84,20 @@
     </ul>
 
     <p class="govuk-body">You can find out more about parenting plans, including a template you can download on the
-      <%= govuk_link_to 'Cafcass website', 'https://www.cafcass.gov.uk/grown-ups/parents-and-carers/divorce-and-separation/parenting-plan/' %>
+      <%= govuk_link_to "Cafcass website", "https://www.cafcass.gov.uk/grown-ups/parents-and-carers/divorce-and-separation/parenting-plan/" %>
       .</p>
 
     <h2 class="govuk-heading-m">Negotiating tools</h2>
     <p class="govuk-body">
-      <%= govuk_link_to 'The Negotiations Cycle tool', 'https://www.separatedfamilies.info/home/parenting-apart/negotiations/' %>
+      <%= govuk_link_to "The Negotiations Cycle tool", "https://www.separatedfamilies.info/home/parenting-apart/negotiations/" %>
       lets you break down your negotiations into 4 stages.</p>
     <p class="govuk-body">Gingerbread has an
-      <%= govuk_link_to 'arrangements fact sheet', 'https://www.gingerbread.org.uk/information/contact-arrangements/making-arrangements-for-your-children/' %>
+      <%= govuk_link_to "arrangements fact sheet", "https://www.gingerbread.org.uk/information/contact-arrangements/making-arrangements-for-your-children/" %>
       that includes tips on making negotiating work.</p>
 
     <h2 class="govuk-heading-m">Letter templates</h2>
     <p class="govuk-body">Child Law Advice has a useful
-      <%= govuk_link_to 'letter template (PDF file - 234kb)', 'https://childlawadvice.org.uk/wp-content/uploads/Residence-template-letter.pdf' %>
+      <%= govuk_link_to "letter template (PDF file - 234kb)", "https://childlawadvice.org.uk/wp-content/uploads/Residence-template-letter.pdf" %>
       if you prefer to negotiate by letter or email.</p>
 
     <h2 class="govuk-heading-l">When negotiating may not be suitable</h2>
@@ -109,17 +109,17 @@
       <li>have a drug or alcohol problem that's affecting your children</li>
     </ul>
     <p class="govuk-body">
-      <%= govuk_link_to 'Find out more about child abuse and neglect', 'https://www.nspcc.org.uk/what-is-child-abuse/types-of-abuse/' %>
+      <%= govuk_link_to "Find out more about child abuse and neglect", "https://www.nspcc.org.uk/what-is-child-abuse/types-of-abuse/" %>
     </p>
 
     <p class="govuk-body">
-      <%= govuk_link_to 'Report child abuse', 'https://www.gov.uk/report-child-abuse-to-local-council' %> if you have
+      <%= govuk_link_to "Report child abuse", "https://www.gov.uk/report-child-abuse-to-local-council" %> if you have
       any concerns and tell your children about
-      <%= govuk_link_to 'Childline', 'https://www.childline.org.uk/' %> so they can report any abuse themselves.
+      <%= govuk_link_to "Childline", "https://www.childline.org.uk/" %> so they can report any abuse themselves.
     </p>
     <p class="govuk-body">
       You can also
-      <%= govuk_link_to 'report a concern about a child online', 'https://www.nspcc.org.uk/keeping-children-safe/reporting-abuse/report/report-abuse-online/' %>
+      <%= govuk_link_to "report a concern about a child online", "https://www.nspcc.org.uk/keeping-children-safe/reporting-abuse/report/report-abuse-online/" %>
       to the National Society for the Prevention of Cruelty to Children (NSPCC).
     </p>
 
@@ -128,11 +128,11 @@
       to you or your children's safety.</p>
 
     <p class="govuk-body">Find out more about
-      <%= govuk_link_to 'signs of domestic violence', 'http://www.refuge.org.uk/our-work/forms-of-violence-and-abuse/domestic-violence/' %>
+      <%= govuk_link_to "signs of domestic violence", "http://www.refuge.org.uk/our-work/forms-of-violence-and-abuse/domestic-violence/" %>
       if you're unsure whether you're a victim.</p>
 
     <p class="govuk-body">
-      <%= govuk_link_to 'Report domestic violence', 'https://www.gov.uk/report-domestic-abuse' %> when it's safe to do
+      <%= govuk_link_to "Report domestic violence", "https://www.gov.uk/report-domestic-abuse" %> when it's safe to do
       so and you think you're a victim.</p>
   </div>
 </section>
@@ -145,18 +145,18 @@
           <h2 class="area_links__heading govuk-heading-l">Negotiation resources</h2>
           <p class="govuk-body">
             GOV.UK has information on
-            <%= govuk_link_to 'arranging child maintenance yourself', 'https://www.gov.uk/making-child-maintenance-arrangement/arrange-child-maintenance-yourself' %>
+            <%= govuk_link_to "arranging child maintenance yourself", "https://www.gov.uk/making-child-maintenance-arrangement/arrange-child-maintenance-yourself" %>
             that includes a
-            <%= govuk_link_to 'child maintenance calculator', 'https://www.gov.uk/calculate-your-child-maintenance' %>
+            <%= govuk_link_to "child maintenance calculator", "https://www.gov.uk/calculate-your-child-maintenance" %>
             .</p>
 
           <p class="govuk-body">Separated Families also has a free
-            <%= govuk_link_to 'online parenting plan', 'https://www.separatedfamilies.info/home/parenting-apart/parenting-agreements/' %>
+            <%= govuk_link_to "online parenting plan", "https://www.separatedfamilies.info/home/parenting-apart/parenting-agreements/" %>
             .</p>
 
           <p class="govuk-body">
             The Parent Connection offers
-            <%= govuk_link_to 'tips on how to communicate with your ex', 'https://click.clickrelationships.org/content/parenting-apart/tips-for-communicating-with-your-ex' %>
+            <%= govuk_link_to "tips on how to communicate with your ex", "https://click.clickrelationships.org/content/parenting-apart/tips-for-communicating-with-your-ex" %>
             .</p>
         </div>
       </div>
@@ -165,8 +165,8 @@
 </section>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
-  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
-  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path),
-  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path)]
+  govuk_link_to(t("pages.professional-mediation.title"), professional_mediation_path),
+  govuk_link_to(t("pages.lawyer-negotiation.title"), lawyer_negotiation_path),
+  govuk_link_to(t("pages.collaborative-law.title"), collaborative_law_path),
+  govuk_link_to(t("pages.going-to-court.title"), going_to_court_path)]
 %>

--- a/app/views/pages/negotiating-between-parents.html.erb
+++ b/app/views/pages/negotiating-between-parents.html.erb
@@ -165,8 +165,8 @@
 </section>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('page_title.mediation'), professional_mediation_path),
-  govuk_link_to(t('page_title.lawyer_negotiation'), lawyer_negotiation_path),
-  govuk_link_to(t('page_title.collaborative'), collaborative_law_path),
-  govuk_link_to(t('page_title.court'), going_to_court_path)]
+  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
+  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
+  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path),
+  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path)]
 %>

--- a/app/views/pages/parental-responsibility.html.erb
+++ b/app/views/pages/parental-responsibility.html.erb
@@ -40,6 +40,6 @@
 </div>
 
 <%= render "shared/prepare_links", links: [
-  govuk_link_to(t('page_title.involving'), involving_children_path),
-  govuk_link_to(t('page_title.support'), emotional_support_path)]
+  govuk_link_to(t('pages.involving-children.title'), involving_children_path),
+  govuk_link_to(t('pages.emotional-support.title'), emotional_support_path)]
 %>

--- a/app/views/pages/parental-responsibility.html.erb
+++ b/app/views/pages/parental-responsibility.html.erb
@@ -17,13 +17,13 @@
     <p class="govuk-body">All mothers automatically have parental responsibility. A father usually does if he's either
       married to the child's mother or listed on the birth certificate.</p>
     <p class="govuk-body">Find out more
-      about <%= govuk_link_to 'who has parental responsibility', 'https://www.gov.uk/parental-rights-responsibilities/who-has-parental-responsibility' %>
+      about <%= govuk_link_to "who has parental responsibility", "https://www.gov.uk/parental-rights-responsibilities/who-has-parental-responsibility" %>
       .</p>
     <p class="govuk-body">You
-      can <%= govuk_link_to 'apply for parental responsibility', 'https://www.gov.uk/parental-rights-responsibilities/apply-for-parental-responsibility' %>
+      can <%= govuk_link_to "apply for parental responsibility", "https://www.gov.uk/parental-rights-responsibilities/apply-for-parental-responsibility" %>
       if you don't automatically have it.</p>
     <p class="govuk-body"><%= govuk_inset_text(text: "You must provide financial support for your children even if you don't have parental responsibility.") %></p>
-    <p class="govuk-body"><%= govuk_link_to 'Arrange child maintenance yourself', 'https://www.gov.uk/making-child-maintenance-arrangement/arrange-child-maintenance-yourself' %></p>
+    <p class="govuk-body"><%= govuk_link_to "Arrange child maintenance yourself", "https://www.gov.uk/making-child-maintenance-arrangement/arrange-child-maintenance-yourself" %></p>
 
     <section id="parental-responsibility-decisions" class="SectionArea govuk-!-margin-top-8 govuk-!-margin-bottom-8">
       <h2 class="govuk-heading-l">Making decisions with the other parent</h2>
@@ -32,14 +32,14 @@
       <p class="govuk-body">If it's a major decision (for example one of you wants to move abroad with your children)
         both parents with responsibility must agree in writing.</p>
       <p class="govuk-body"> You can apply for
-        a <%= govuk_link_to 'Specific Issue Order', 'https://www.compactlaw.co.uk/free-legal-information/children/specific-issue-order.html' %>
-        or <%= govuk_link_to 'Prohibited Steps Order', 'https://www.lawandparents.co.uk/prohibited-steps-orders-effect-parents.html' %>
+        a <%= govuk_link_to "Specific Issue Order", "https://www.compactlaw.co.uk/free-legal-information/children/specific-issue-order.html" %>
+        or <%= govuk_link_to "Prohibited Steps Order", "https://www.lawandparents.co.uk/prohibited-steps-orders-effect-parents.html" %>
         if you can't agree. A judge will then make a decision which is in your children's best interests.</p>
     </section>
   </div>
 </div>
 
 <%= render "shared/prepare_links", links: [
-  govuk_link_to(t('pages.involving-children.title'), involving_children_path),
-  govuk_link_to(t('pages.emotional-support.title'), emotional_support_path)]
+  govuk_link_to(t("pages.involving-children.title"), involving_children_path),
+  govuk_link_to(t("pages.emotional-support.title"), emotional_support_path)]
 %>

--- a/app/views/pages/professional-mediation-other-parent.html.erb
+++ b/app/views/pages/professional-mediation-other-parent.html.erb
@@ -82,9 +82,9 @@
 <%= render "shared/mediation_resources" %>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
-  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
-  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
-  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path),
-  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path)]
+  govuk_link_to(t("pages.professional-mediation.title"), professional_mediation_path),
+  govuk_link_to(t("pages.negotiating-between-parents.title"), negotiating_between_parents_path),
+  govuk_link_to(t("pages.lawyer-negotiation.title"), lawyer_negotiation_path),
+  govuk_link_to(t("pages.collaborative-law.title"), collaborative_law_path),
+  govuk_link_to(t("pages.going-to-court.title"), going_to_court_path)]
 %>

--- a/app/views/pages/professional-mediation-other-parent.html.erb
+++ b/app/views/pages/professional-mediation-other-parent.html.erb
@@ -5,18 +5,6 @@
     <p class="govuk-body-lead">You may have been contacted by a mediator or the other parent may have asked you to try mediation. It's important to understand what mediation is and how it could help your situation.</p>
     <p class="govuk-body">The other parent may have approached a professional mediator because they want help to reach a decision about arrangements for your children. Or you may have been invited to a 'Mediation Information and Assessment Meeting' or 'MIAM', which is a legal requirement before the other parent can apply to court.</p>
 
-    <section id="going-to-court-other-parent-before" class="SectionArea">
-      <h2 class="area_links__heading govuk-heading-l">Before they've applied</h2>
-      <p class="govuk-body">
-        Before the other parent can apply for a court order about your child arrangements, they must show they've attended a meeting about mediation, <%= govuk_link_to "except in certain cases", "https://apply-to-court-about-child-arrangements.service.justice.gov.uk/about/miam_exemptions" %>.
-        This is called a MIAM or Mediation Information and Assessment Meeting. The mediator will <%= govuk_link_to "invite you to a meeting too", "/professional-mediation-other-parent" %>.
-      </p>
-      <p class="govuk-body">
-        There's usually a better outcome for children and parents if you can reach an agreement without going to court.
-        So if there are no safety concerns, you should talk to the other parent about different options such as <%= govuk_link_to "negotiation", "/negotiating-between-parents" %> or <%= govuk_link_to "professional mediation", "/professional-mediation" %>.
-      </p>
-    </section>
-
     <section id="mediation-other-should-i-go" class="SectionArea">
       <h2 class="area_links__heading govuk-heading-l">Should I go to mediation?</h2>
       <p class="govuk-body">It may have come as a surprise to you that your ex wants to change something regarding the arrangements for your child or children. A letter from a mediator may have been completely unexpected. If you're fine with the arrangements as they are, why should you contact the mediator?</p>
@@ -65,7 +53,7 @@
     <div class="cost govuk-grid-column-one-third govuk-!-margin-top-3">
       <h4 class="cost__heading govuk-heading-s">Average cost of mediation per person</h4>
       <p class="cost__amount govuk-heading-l"><strong>&pound;480</strong></p>
-      <p class="govuk-body-xs">Estimated cost based on an average of <strong>3</strong> sessions. Fees may vary depending on your location and the experience of the mediator. Some mediators offer reductions if you're unemployed or on a low income. <%= govuk_link_to "Legal aid may be available for mediation", "https://www.nfm.org.uk/mediation-faq/can-i-get-legal-aid/" %>.</p>
+      <p class="govuk-body-xs">Estimated cost based on an average of <strong>3</strong> sessions. Fees may vary depending on your location and the experience of the mediator. Some mediators offer reductions if you're unemployed or on a low income. <%= govuk_link_to "Legal aid may be available for mediation", "https://www.nfm.org.uk/mediation-faq/mediation/what-is-legally-aided-family-mediation" %>.</p>
     </div>
   </section>
 </div>

--- a/app/views/pages/professional-mediation-other-parent.html.erb
+++ b/app/views/pages/professional-mediation-other-parent.html.erb
@@ -36,7 +36,7 @@
       <p class="govuk-body">Advice Now has a <%= govuk_link_to "guide to using mediation following separation", "https://www.advicenow.org.uk/guides/survival-guide-using-family-mediation-after-break" %>, which contains information about costs.</p>
     </div>
 
-    <div class="cost govuk-grid-column-one-third govuk-!-margin-top-3">
+    <div class="cost govuk-grid-column-one-third govuk-!-margin-top-8">
       <h4 class="cost__heading govuk-heading-s">Average cost of MIAM per person</h4>
       <p class="cost__amount govuk-heading-l"><strong>&pound;90</strong></p>
       <p class="govuk-body-xs">It may be cheaper if you attend together.</p>

--- a/app/views/pages/professional-mediation-other-parent.html.erb
+++ b/app/views/pages/professional-mediation-other-parent.html.erb
@@ -94,9 +94,9 @@
 <%= render "shared/mediation_resources" %>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('page_title.mediation'), professional_mediation_path),
-  govuk_link_to(t('page_title.negotiation'), negotiating_between_parents_path),
-  govuk_link_to(t('page_title.lawyer_negotiation'), lawyer_negotiation_path),
-  govuk_link_to(t('page_title.collaborative'), collaborative_law_path),
-  govuk_link_to(t('page_title.court'), going_to_court_path)]
+  govuk_link_to(t('pages.professional-mediation.title'), professional_mediation_path),
+  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
+  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
+  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path),
+  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path)]
 %>

--- a/app/views/pages/professional-mediation.html.erb
+++ b/app/views/pages/professional-mediation.html.erb
@@ -7,11 +7,11 @@
     <p class="govuk-body">Mediation isn't relationship counselling and you don't have to be in the same room as the
       other parent.</p>
 
-    <%= govuk_inset_text(html_attributes: { lang: "en-GB", data: { demo: true }, aria: { role: 'note' } }) do %>
+    <%= govuk_inset_text(html_attributes: { lang: "en-GB", data: { demo: true }, aria: { role: "note" } }) do %>
       <p class="govuk-body"><strong>You could get up to &pound;500 towards family mediation</strong></p>
       <p class="govuk-body">This is a new scheme available for a short time only.<br>
         Find out more about the
-        <%= govuk_link_to 'family mediation voucher scheme', 'https://www.gov.uk/guidance/family-mediation-voucher-scheme?utm_source=CAIT&utm_campaign=mediation_vouchers' %>
+        <%= govuk_link_to "family mediation voucher scheme", "https://www.gov.uk/guidance/family-mediation-voucher-scheme?utm_source=CAIT&utm_campaign=mediation_vouchers" %>
         .</p>
     <% end %>
 
@@ -224,7 +224,7 @@
           <p class="govuk-body-xs">Estimated cost based on an average of 3 sessions. Fees may vary depending on your
             location and the experience of the mediator. Some mediators offer reductions if you're unemployed or on a
             low income.
-            <%= govuk_link_to 'Legal aid may be available for mediation', 'https://www.nfm.org.uk/about-family-mediation-services/legal-aid-for-mediation/' %>
+            <%= govuk_link_to "Legal aid may be available for mediation", "https://www.nfm.org.uk/about-family-mediation-services/legal-aid-for-mediation/" %>
             .</p>
         </div>
       </div>
@@ -333,8 +333,8 @@
 <%= render "shared/mediation_resources" %>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
-  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
-  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path),
-  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path)]
+  govuk_link_to(t("pages.negotiating-between-parents.title"), negotiating_between_parents_path),
+  govuk_link_to(t("pages.lawyer-negotiation.title"), lawyer_negotiation_path),
+  govuk_link_to(t("pages.collaborative-law.title"), collaborative_law_path),
+  govuk_link_to(t("pages.going-to-court.title"), going_to_court_path)]
 %>

--- a/app/views/pages/professional-mediation.html.erb
+++ b/app/views/pages/professional-mediation.html.erb
@@ -338,8 +338,8 @@
 <%= render "shared/mediation_resources" %>
 
 <%= render "shared/agreement_links", links: [
-  govuk_link_to(t('page_title.negotiation'), negotiating_between_parents_path),
-  govuk_link_to(t('page_title.lawyer_negotiation'), lawyer_negotiation_path),
-  govuk_link_to(t('page_title.collaborative'), collaborative_law_path),
-  govuk_link_to(t('page_title.court'), going_to_court_path)]
+  govuk_link_to(t('pages.negotiating-between-parents.title'), negotiating_between_parents_path),
+  govuk_link_to(t('pages.lawyer-negotiation.title'), lawyer_negotiation_path),
+  govuk_link_to(t('pages.collaborative-law.title'), collaborative_law_path),
+  govuk_link_to(t('pages.going-to-court.title'), going_to_court_path)]
 %>

--- a/app/views/pages/professional-mediation.html.erb
+++ b/app/views/pages/professional-mediation.html.erb
@@ -43,17 +43,15 @@
           <span data-block-name="pros_cons__heading--pros">Pros</span>
         </h4>
         <ul class="pros_cons__list govuk-list pros_cons__list--pros">
-          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">cheapest and quickest
-            option
+          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">it's quicker than court in most cases
           </li>
-          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">you and the other parent
-            are in control
+          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">can be cheaper than using a lawyer
           </li>
-          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">helps children continue
-            family relationships
+          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">less conflict between parents
           </li>
-          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">agreements are
-            flexible
+          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">helps children continue family relationships
+          </li>
+          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">agreements are flexible
           </li>
         </ul>
       </div>
@@ -62,12 +60,9 @@
           <span data-block-name="pros_cons__heading--cons">Cons</span>
         </h4>
         <ul class="pros_cons__list govuk-list pros_cons__list--cons">
-          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--cons">you'll need a consent
-            order to make agreement legally
-            binding
+          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--cons">you'll need a consent order to make agreement legally binding
           </li>
-          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--cons">process heavily relies
-            on parent co-operation
+          <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--cons">process won't work unless parents can co-operate
           </li>
         </ul>
       </div>

--- a/app/views/pages/professional-mediation.html.erb
+++ b/app/views/pages/professional-mediation.html.erb
@@ -170,7 +170,7 @@
           </div>
         </div>
 
-        <div class="cost govuk-grid-column-one-third govuk-!-margin-top-4">
+        <div class="cost govuk-grid-column-one-third govuk-!-margin-top-2">
           <h4 class="cost__heading govuk-heading-s">Average cost of MIAM per person</h4>
           <p class="cost__amount govuk-heading-l"><strong>&pound;90</strong></p>
           <p class="govuk-body-xs">Estimated fees may vary depending on your location and the experience of the
@@ -218,7 +218,7 @@
           </div>
         </div>
 
-        <div class="cost govuk-grid-column-one-third govuk-!-margin-top-4">
+        <div class="cost govuk-grid-column-one-third govuk-!-margin-top-2">
           <h4 class="cost__heading govuk-heading-s">Average cost of mediation per person</h4>
           <p class="cost__amount govuk-heading-l"><strong>&pound;480</strong></p>
           <p class="govuk-body-xs">Estimated cost based on an average of 3 sessions. Fees may vary depending on your

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
       title: If the other parent is applying to court
     involving-children:
       title: Putting your children first
-    lawyer_negotiation:
+    lawyer-negotiation:
       title: Lawyer negotiation
     negotiating-between-parents:
       title: Negotiation tools and services


### PR DESCRIPTION
- Use correct translations
- Add missing text
- Use double quotes
- Tweak some spacing to better match current site