### PR TITLE
CDPT-1952 Enable modsec detection mode on production

### DIFF
--- a/config/kubernetes/production/ingress.yaml
+++ b/config/kubernetes/production/ingress.yaml
@@ -1,10 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: help-with-child-arrangements-ingress
+  name: help-with-child-arrangements-ingress-modsec
   namespace: help-with-child-arrangements-production
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: help-with-child-arrangements-ingress-help-with-child-arrangements-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: help-with-child-arrangements-ingress-modsec-help-with-child-arrangements-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |

--- a/config/kubernetes/production/ingress.yaml
+++ b/config/kubernetes/production/ingress.yaml
@@ -6,7 +6,13 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: help-with-child-arrangements-ingress-help-with-child-arrangements-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=help-with-child-arrangements-production"
 spec:
+  ingressClassName: modsec
   tls:
   - hosts:
     - help-with-child-arrangements.apps.live.cloud-platform.service.justice.gov.uk

--- a/config/kubernetes/staging/ingress.yaml
+++ b/config/kubernetes/staging/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
 spec:
+  ingressClassName: default
   tls:
   - hosts:
     - staging-help-with-child-arrangements.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## Description
Enables [modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) in detection mode on production so we can be aware of any issues and evaluate if more protection is required.