### PR TITLE
CDPT-1958 Enable modsec in non-prod namespaces

### DIFF
--- a/config/kubernetes/staging/ingress.yaml
+++ b/config/kubernetes/staging/ingress.yaml
@@ -8,8 +8,12 @@ metadata:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=help-with-child-arrangements-staging"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
   - hosts:
     - staging-help-with-child-arrangements.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## Description
[Modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) will stop malicious traffic going to the service.