### PR TITLE
Correct the fees for going to court

### DIFF
--- a/app/views/pages/going-to-court.html.erb
+++ b/app/views/pages/going-to-court.html.erb
@@ -221,7 +221,7 @@
           </h2>
 
           <div class="step__content">
-            <p class="govuk-body">Use the <%= govuk_link_to "online service", "https://apply-to-court-about-child-arrangements.service.justice.gov.uk/" %> to apply to court about child arrangements. It costs £232 to apply.</p>
+            <p class="govuk-body">Use the <%= govuk_link_to "online service", "https://apply-to-court-about-child-arrangements.service.justice.gov.uk/" %> to apply to court about child arrangements. It costs £255 to apply.</p>
             <p class="govuk-body">
               Alternatively fill in the C100 form to <%= govuk_link_to "make an application", "https://www.gov.uk/looking-after-children-divorce/apply-for-court-order" %>
               and send it to the family court closest to where your child lives.
@@ -250,7 +250,7 @@
         </div>
         <div class="cost govuk-grid-column-one-third">
           <h4 class="cost__heading govuk-heading-s">Cost of C100 court application</h4>
-          <p class="cost__amount govuk-heading-l"><strong>&pound;232</strong></p>
+          <p class="cost__amount govuk-heading-l"><strong>&pound;255</strong></p>
           <p class="govuk-body-xs">Only applicant needs to pay the fee.</p>
         </div>
       </div>


### PR DESCRIPTION
Step 4 Going to Court states that it costs _£232 amended to £255_ to apply to court for child arrangements.
Amended summary in bold on the right side to £255.