### PR TITLE
CDPT-2647 update court application cost

### DIFF
--- a/app/views/pages/emotional-support.html.erb
+++ b/app/views/pages/emotional-support.html.erb
@@ -122,9 +122,9 @@
           <section id="emotional-support-resources" class="ResourcesSection govuk-!-margin-bottom-8">
             <h2 class="govuk-heading-l">Getting emotional support resources</h2>
             <p class="govuk-body"><%= govuk_link_to "Find out more about counselling", "https://www.counselling-directory.org.uk/separation.html" %></p>
-            <p class="govuk-body">Relate has a <%= govuk_link_to "30 minute telephone call service", "https://www.relate.org.uk/get-help/which-service-right-you/chat-us" %> that costs £30.</p>
+            <p class="govuk-body">Relate has a <%= govuk_link_to "30 minute telephone call service", "https://www.relate.org.uk/get-help/which-service-right-you/chat-us" %> that costs &pound;30.</p>
 
-            <p class="govuk-body">Relate also offers an <%= govuk_link_to "email service", "https://www.relate.org.uk/get-help/which-service-right-you/message-counsellor" %> that is equivalent to one hour of counselling. It costs £45 per session. </p>
+            <p class="govuk-body">Relate also offers an <%= govuk_link_to "email service", "https://www.relate.org.uk/get-help/which-service-right-you/message-counsellor" %> that is equivalent to one hour of counselling. It costs &pound;45 per session. </p>
           </section>
         </div>
       </div>

--- a/app/views/pages/going-to-court.html.erb
+++ b/app/views/pages/going-to-court.html.erb
@@ -221,7 +221,7 @@
           </h2>
 
           <div class="step__content">
-            <p class="govuk-body">Use the <%= govuk_link_to "online service", "https://apply-to-court-about-child-arrangements.service.justice.gov.uk/" %> to apply to court about child arrangements. It costs £255 to apply.</p>
+            <p class="govuk-body">Use the <%= govuk_link_to "online service", "https://apply-to-court-about-child-arrangements.service.justice.gov.uk/" %> to apply to court about child arrangements. It costs &pound;263 to apply.</p>
             <p class="govuk-body">
               Alternatively fill in the C100 form to <%= govuk_link_to "make an application", "https://www.gov.uk/looking-after-children-divorce/apply-for-court-order" %>
               and send it to the family court closest to where your child lives.
@@ -250,7 +250,7 @@
         </div>
         <div class="cost govuk-grid-column-one-third">
           <h4 class="cost__heading govuk-heading-s">Cost of C100 court application</h4>
-          <p class="cost__amount govuk-heading-l"><strong>&pound;255</strong></p>
+          <p class="cost__amount govuk-heading-l"><strong>&pound;263</strong></p>
           <p class="govuk-body-xs">Only applicant needs to pay the fee.</p>
         </div>
       </div>

--- a/app/views/pages/homepage.html.erb
+++ b/app/views/pages/homepage.html.erb
@@ -271,7 +271,7 @@
                 <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">agreements are
                   flexible
                 </li>
-                <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">You may be eligible for a £500 voucher
+                <li class="pros_cons__item govuk-list govuk-!-font-size-14 pros_cons__item--pros">You may be eligible for a &pound;500 voucher
                 </li>
               </ul>
             </div>

--- a/app/views/pages/professional-mediation-other-parent.html.erb
+++ b/app/views/pages/professional-mediation-other-parent.html.erb
@@ -54,7 +54,7 @@
       <h4 class="cost__heading govuk-heading-s">Average cost of mediation per person</h4>
       <p class="cost__amount govuk-heading-l"><strong>&pound;480</strong></p>
        <p class="govuk-body-xs">
-        You could get up to £500 towards family mediation
+        You could get up to &pound;500 towards family mediation
         Find out more about the <%= govuk_link_to "family mediation voucher scheme", "https://www.gov.uk/guidance/family-mediation-voucher-scheme?utm_source=CAIT&utm_campaign=mediation_vouchers" %>.
       </p>
       <p class="govuk-body-xs">

--- a/app/views/pages/professional-mediation.html.erb
+++ b/app/views/pages/professional-mediation.html.erb
@@ -222,7 +222,7 @@
           <p class="govuk-body-xs">Estimated cost based on an average of 3 sessions. Fees may vary depending on your
             location and the experience of the mediator. Some mediators offer reductions if you're unemployed or on a low income.
             <%= govuk_link_to "Legal aid may be available for mediation", "https://www.gov.uk/check-legal-aid" %>.
-            You could get up to £500 towards family mediation.
+            You could get up to &pound;500 towards family mediation.
           </p>
         </div>
       </div>


### PR DESCRIPTION
**Description**
Update the cost of applying for a court order in step 4 from £255 to £263.  This change applies from the 8th April 2025 and can be found on this page:

https://helpwithchildarrangements.service.justice.gov.uk/going-to-court

Also replaced each instance of the '£' character with the '&pound;' character entity. 

**Jira ticket:**
https://dsdmoj.atlassian.net/browse/CDPT-2647

---
![cait-court-application-cost-update](https://github.com/user-attachments/assets/599c8bb2-4f73-422f-a455-042864980cd7)


