### PR TITLE
CDPT-2538:CAIT Remove Heading Links and Show Mobile Navigation

### DIFF
--- a/app/views/pages/homepage.html.erb
+++ b/app/views/pages/homepage.html.erb
@@ -50,8 +50,6 @@
           </p>
         </div>
 
-
-
         <aside class="summary_area__aside">
           <div class="summary_area__concerning">
             <h3 class="summary_area__concerning__heading  govuk-heading-m" role="presentation">


### PR DESCRIPTION
It’s not best practise to have headings as links - remove the links.
 
The mobile version has navigational links after each sections text.  Make these visible for desktop

