### PR TITLE
cdpt-2530-incorrect-gov-uk-link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,8 +38,7 @@
     <!-- End Google Tag Manager (noscript) -->
 
     <%= govuk_skip_link %>
-
-    <%= govuk_header(service_name: "Get help with child arrangements")  %>
+    <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: "Get help with child arrangements") %>
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(tag: { text: "Beta" }, text: "This is the first version of the guide") %>


### PR DESCRIPTION
The gov.uk link incorrectly takes you to the CAIT home page instead of Welcome to GOV.UK