### PR TITLE
Revert "Bump net-imap from 0.4.16 to 0.4.20 (#326)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
-    date (3.4.1)
+    date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -175,7 +175,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.25.4)
-    net-imap (0.4.20)
+    net-imap (0.4.16)
       date
       net-protocol
     net-pop (0.1.2)
@@ -541,7 +541,7 @@ GEM
     statsd-ruby (1.5.0)
     stringio (3.1.2)
     thor (1.3.2)
-    timeout (0.4.3)
+    timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)


### PR DESCRIPTION
not needed created in error.